### PR TITLE
chown to glance user if image directory is not default.

### DIFF
--- a/doc/install-guide/source/glance-install.rst
+++ b/doc/install-guide/source/glance-install.rst
@@ -367,6 +367,12 @@ Install and configure components
 
          Ignore any deprecation messages in this output.
 
+      .. note::
+
+         Change owner and group to glance if image directory is not default.
+         ``chown -R glance:glance /your/glance/image/dir/``
+
+
 .. endonly
 
 Finalize installation


### PR DESCRIPTION
Change owner and group to glance command with note, if image directory is not default.